### PR TITLE
Corrected container tag / Docker-hub location

### DIFF
--- a/.github/workflows/driver-did-btcr-ws.yml
+++ b/.github/workflows/driver-did-btcr-ws.yml
@@ -19,4 +19,4 @@ jobs:
         DOCKER_USERNAME: ${{secrets.DOCKER_USERNAME}}
         DOCKER_PASSWORD: ${{secrets.DOCKER_PASSWORD}}
         DOCKER_FILE: docker/Dockerfile
-        CONTAINER_TAG: phil21/driver-did-btcr:latest
+        CONTAINER_TAG: universalresolver/driver-did-btcr:latest


### PR DESCRIPTION
Changed the containter tag so the docker push goes to the correct location. Please make sure that the following GitHub secretes are set correctly.

DOCKER_PASSWORD
DOCKER_USERNAME